### PR TITLE
Added findClosestVertex method

### DIFF
--- a/threeoctree.js
+++ b/threeoctree.js
@@ -561,6 +561,57 @@
 			return results;
 			
 		},
+
+		findClosestVertex: function(position, radius) {
+
+			var search = this.search(position, radius, true);
+
+			if (!search[0]) {
+
+				return null;
+
+			}
+
+			var object = search[0].object,
+				vertices = search[0].vertices;
+
+			if( vertices.length === 0 ){
+
+				return null;
+
+			}
+
+			var distance,
+				vertex = null,
+				localPosition = object.worldToLocal(position.clone());
+
+			for (var i = 0, il = vertices.length; i <il; i++) {
+
+				distance = vertices[i].distanceTo(localPosition);
+
+				if (distance > radius) {
+
+					continue;
+
+				}
+
+				// use distance in new comparison to find the closest point
+
+				radius = distance;
+
+				vertex = vertices[i];
+
+			}
+
+			if (vertex === null) {
+
+				return null;
+
+			}
+
+			return object.localToWorld(vertex);
+
+		},
 		
 		setRoot: function ( root ) { 
 			


### PR DESCRIPTION
Added `findClosestVertex` method to threeoctree.
This can for example be used for implementing snapping functionality (to snap to points within certain radius of the mouse pointer).