### PR TITLE
Bug in `findClosestVertex` method

### DIFF
--- a/threeoctree.js
+++ b/threeoctree.js
@@ -609,7 +609,7 @@
 
 			}
 
-			return object.localToWorld(vertex);
+			return object.localToWorld(vertex.clone());
 
 		},
 		

--- a/threeoctree.js
+++ b/threeoctree.js
@@ -609,7 +609,7 @@
 
 			}
 
-			return object.localToWorld(vertex.clone());
+			return object.localToWorld( vertex.clone() );
 
 		},
 		


### PR DESCRIPTION
Fixes a bug in `findClosestVertex` method.
The vertex should be cloned before changing it from local to world space