### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-## Version compatible with latest THREEJS: https://github.com/mrdoob/three.js/blob/dev/examples/js/Octree.js
-
 ﻿threeoctree.js (r60)
 ========
 


### PR DESCRIPTION
`THREE.Octree` has been removed from the `three.js` repo, see https://github.com/mrdoob/three.js/pull/15451